### PR TITLE
target field of SRV announce must end with .local

### DIFF
--- a/zeroconf.c
+++ b/zeroconf.c
@@ -389,7 +389,7 @@ OpcUa_StatusCode OPCUA_DLLCALL ualds_zeroconf_registerInternal(OpcUa_Void*  pvCa
             char hostname[UALDS_CONF_MAX_URI_LENGTH+6] = {0};
             ualds_platform_getfqhostname(hostname, sizeof(hostname));
             replace_string(szMDNSServerName, UALDS_CONF_MAX_URI_LENGTH, "[gethostname]", hostname);
-            // hostname must end with .local
+            // hostname must end with .local to be a FQDN
             sprintf(hostname + strlen(hostname), ".local");
             replace_string(szHostName, UALDS_CONF_MAX_URI_LENGTH, "[gethostname]", hostname);
             bOwnRegistration = OpcUa_False;

--- a/zeroconf.c
+++ b/zeroconf.c
@@ -385,9 +385,12 @@ OpcUa_StatusCode OPCUA_DLLCALL ualds_zeroconf_registerInternal(OpcUa_Void*  pvCa
         /* replace [gethostname] in own server name */
         if (bOwnRegistration != OpcUa_False)
         {
-            char hostname[UALDS_CONF_MAX_URI_LENGTH] = {0};
+            // additional 6 chars for '.local'
+            char hostname[UALDS_CONF_MAX_URI_LENGTH+6] = {0};
             ualds_platform_getfqhostname(hostname, sizeof(hostname));
             replace_string(szMDNSServerName, UALDS_CONF_MAX_URI_LENGTH, "[gethostname]", hostname);
+            // hostname must end with .local
+            sprintf(hostname + strlen(hostname), ".local");
             replace_string(szHostName, UALDS_CONF_MAX_URI_LENGTH, "[gethostname]", hostname);
             bOwnRegistration = OpcUa_False;
         }


### PR DESCRIPTION
The hostname field of an mDNS announcement has to contain either a valid global FQDN, or otherwise it has to end with `.local` (see https://tools.ietf.org/html/rfc6762#section-3)


Currently the LDS announces its service through mDNS via:

```
        UA Local Discovery Server._opcua-tcp._tcp.local: type TXT, class IN, cache flush
            Name: UA Local Discovery Server._opcua-tcp._tcp.local
            Type: TXT (Text strings) (16)
            .000 0000 0000 0001 = Class: IN (0x0001)
            1... .... .... .... = Cache flush: True
            Time to live: 4500
            Data length: 9
            TXT Length: 8
            TXT: caps=LDS
        UA Local Discovery Server._opcua-tcp._tcp.local: type SRV, class IN, cache flush, priority 0, weight 0, port 4840, target myhostname
            Service: UA Local Discovery Server
            Protocol: _opcua-tcp
            Name: _tcp.local
            Type: SRV (Server Selection) (33)
            .000 0000 0000 0001 = Class: IN (0x0001)
            1... .... .... .... = Cache flush: True
            Time to live: 120
            Data length: 8
            Priority: 0
            Weight: 0
            Port: 4840
            Target: myhostname
```

So to get the IP address of the LDS server, the remote client performs an mDNS query for A record of `myhostname`.
Since this is not a valid hostname, nobody responds with the corresponding ip address.

To fix this, the LDS server needs to announce itself with the `Target: myhostname.local`

Using the additional `.local` the corresponding IP Address can be found:
```
        myhostname.local: type A, class IN, cache flush, addr 10.100.1.0
            Name: myhostname.local
            Type: A (Host Address) (1)
            .000 0000 0000 0001 = Class: IN (0x0001)
            1... .... .... .... = Cache flush: True
            Time to live: 120
            Data length: 4
            Address: 10.100.1.0
```

You can also test this with the following simple python script:

```
from zeroconf import *
import socket
import time

class ServiceListener(object):
    def remove_service(self, zeroconf, type, name):
        print
        print "Service", name, "removed"

    def add_service(self, zeroconf, type, name):
        print
        print "Service", name, "added"
        print "  Type is", type
        info = zeroconf.get_service_info(type, name)
        if info:
            print "  Address is %s:%d" % (socket.inet_ntoa(info.address),
                                          info.port)
            print "  Weight is %d, Priority is %d" % (info.weight,
                                                      info.priority)
            print "  Server is", info.server
            prop = info.properties
            if prop:
                print "  Properties are"
                for key, value in prop.items():
                    print "    %s: %s" % (key, value)

if __name__ == '__main__':
    r = Zeroconf()

    desc = {'path': '/',
            'caps': 'LDS'}
    info = ServiceInfo("_opcua-tcp._tcp.local.",
                       "Python OPC UA._opcua-tcp._tcp.local.",
                       socket.inet_aton("127.0.0.1"), 1234, 0, 0,
                       desc, "some-host.local")

    r.register_service(info,10);

    listener = ServiceListener()
    browser = ServiceBrowser(r, "_opcua-tcp._tcp.local.", [], listener)
    # Search for devices for 40 seconds.
    time.sleep(4000)
    r.close()
```

First start the LDS without this Pull Request, and you see:

```
Service Python OPC UA._opcua-tcp._tcp.local. added
  Type is _opcua-tcp._tcp.local.
  Address is 127.0.0.1:1234
  Weight is 0, Priority is 0
  Server is some-host.local.
  Properties are
    path: /
    caps: LDS

Service UA Local Discovery Server._opcua-tcp._tcp.local. added
  Type is _opcua-tcp._tcp.local.
```

This means the service info for `UA Local Discovery Server._opcua-tcp._tcp.local.` could not be detected.
Now integrate my pull request and you see:

```
Service UA Local Discovery Server._opcua-tcp._tcp.local. added
  Type is _opcua-tcp._tcp.local.
  Address is 10.100.1.0:4840
  Weight is 0, Priority is 0
  Server is myhostname.local.
  Properties are
    caps: LDS

Service Python OPC UA._opcua-tcp._tcp.local. added
  Type is _opcua-tcp._tcp.local.
  Address is 127.0.0.1:1234
  Weight is 0, Priority is 0
  Server is some-host.local.
  Properties are
    path: /
    caps: LDS
```
