### PR TITLE
Set default value for path

### DIFF
--- a/zeroconf.c
+++ b/zeroconf.c
@@ -284,6 +284,9 @@ OpcUa_StatusCode ualds_zeroconf_getServerInfo(const char *szServerUri,
         {
             TXTRecordSetValue(txtRecord, "path", (uint8_t)strlen(szPath), szPath);
         }
+        else {
+            TXTRecordSetValue(txtRecord, "path", 1, "/");
+        }
 
         ualds_settings_beginreadarray("ServerCapabilities", &numCapabilities);
         if (numCapabilities > 0)


### PR DESCRIPTION
The path part should be set to the default value in the TXT record