### PR TITLE
Migrated implementation for 'ualds_platform_mkpath' from linux to windows platform

### DIFF
--- a/ualds.c
+++ b/ualds.c
@@ -661,6 +661,10 @@ OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_security_initialize");
     ualds_settings_begingroup("PKI");
 
     UALDS_SETTINGS_READSTRING(CertificateStorePath);
+    if (g_szCertificateStorePath[0] == 0)
+    {
+        ualds_log(UALDS_LOG_WARNING, "Certificate store path (Section: 'PKI', Key: 'CertificateStorePath') is not set in the settings file!");
+    }
 
     //check if path ends with dir separator
     char* directory_separator = __ualds_plat_path_sep;

--- a/win32/platform.c
+++ b/win32/platform.c
@@ -232,59 +232,59 @@ int ualds_platform_rm(char *szFilePath)
 
 int ualds_platform_mkdir(char *szFilePath, int mode)
 {
-    /* Not supported on windows - return failure to caller */
+	/* Not supported on windows - return failure to caller */
     return -1;
 }
 
 int ualds_platform_mkpath(char *szFilePath)
 {
-	char *path = strdup(szFilePath);
-	int ret = 0;
-	char *szFind = path;
-	char *szFindNext = szFind;
+    char *path = strdup(szFilePath);
+    int ret = 0;
+    char *szFind = path;
+    char *szFindNext = szFind;
 
-	/* be sure to not have a normal backspace */
-	char *szRepl;
-	szRepl = path;
-	while (*szRepl)
-	{
-		if (*szRepl == '/') *szRepl = '\\';
-		szRepl++;
-	}
+    /* be sure to not have a normal backspace */
+    char *szRepl;
+    szRepl = path;
+    while (*szRepl)
+    {
+        if (*szRepl == '/') *szRepl = '\\';
+        szRepl++;
+    }
 
-	/* create parent directories */
-	while ((ret == 0 || errno == EEXIST) && ((szFindNext = strchr(szFind, '\\')) != NULL))
-	{
-		if (szFindNext != szFind)
-		{
-			*szFindNext = 0;   /* replace '/' with \0 */
-			ret = _mkdir(path);
-			if (ret < 0 && errno != EEXIST)
-			{
-				ualds_log(UALDS_LOG_WARNING, "Failed making %s error %s\n", path, strerror(errno));
-			}
-			*szFindNext = '\\'; /* restore '/' */
-		}
-		szFind = szFindNext + 1;
-	}
+    /* create parent directories */
+    while ((ret == 0 || errno == EEXIST) && ((szFindNext = strchr(szFind, '\\')) != NULL))
+    {
+        if (szFindNext != szFind)
+        {
+            *szFindNext = 0;   /* replace '/' with \0 */
+            ret = _mkdir(path);
+            if (ret < 0 && errno != EEXIST)
+            {
+                ualds_log(UALDS_LOG_WARNING, "Failed making %s error %s\n", path, strerror(errno));
+            }
+            *szFindNext = '\\'; /* restore '\\' */
+        }
+        szFind = szFindNext + 1;
+    }
 
-	/* create last dir */
-	if (ret == 0 || errno == EEXIST)
-	{
-		ret = _mkdir(path);
-		if (ret < 0 && errno != EEXIST)
-		{
-			ualds_log(UALDS_LOG_WARNING, "Failed making %s error %s\n", path, strerror(errno));
-		}
-	}
+    /* create last dir */
+    if (ret == 0 || errno == EEXIST)
+    {
+        ret = _mkdir(path);
+        if (ret < 0 && errno != EEXIST)
+        {
+            ualds_log(UALDS_LOG_WARNING, "Failed making %s error %s\n", path, strerror(errno));
+        }
+    }
 
-	if (ret < 0 && errno == EEXIST)
-	{
-		ret = 0;
-	}
+    if (ret < 0 && errno == EEXIST)
+    {
+        ret = 0;
+    }
 
-	free(path);
-	return ret;
+    free(path);
+    return ret;
 }
 
 UALDS_FILE* ualds_platform_fopen(const char *path, const char *mode)


### PR DESCRIPTION
Hi all,

the function "ualds_platform_mkpath" is not implemented in the windows version. This sometimes leads to Problems if the directories are not created in advance.
This pull request has migrated the already implemented Linux Version of this function to the windows platform.c file.
The only changes are from "/" to "\\" and we must be sure, that all "/" are replaced by "\\". So the pull request shouldn´t be too complicated. It affects only the file "win32/platform.c".