### PR TITLE
OpcUa_InitializeStatus: Added warning if 'CertificateStorePath' is not set in configuration

### DIFF
--- a/ualds.c
+++ b/ualds.c
@@ -661,6 +661,10 @@ OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_security_initialize");
     ualds_settings_begingroup("PKI");
 
     UALDS_SETTINGS_READSTRING(CertificateStorePath);
+    if (g_szCertificateStorePath[0] == 0)
+    {
+        ualds_log(UALDS_LOG_WARNING, "Certificate store path (Section: 'PKI', Key: 'CertificateStorePath') is not set in the settings file!");
+    }
 
     //check if path ends with dir separator
     char* directory_separator = __ualds_plat_path_sep;


### PR DESCRIPTION
If the "CertificateStorePath' is not set in the configuration you will never see it. It will then use the directory of the application. There is no hint on why this Directory is used. So it is a good practice to at least log, what the problem is.
This is just a small log enhancement.