### PR TITLE
New setting 'LogRotateCount' to restrict the number of logfiles

### DIFF
--- a/etc/ualds.ini
+++ b/etc/ualds.ini
@@ -77,6 +77,8 @@ LogLevel = info
 LogFileSize = 100
 # Activate UaStack trace: off, error, warn, info, debug
 StackTrace = error
+# LogRotateCount: Maximum number of logfiles. This is optional for LogSystem=file. Default is '0' (no restriction in logfiles)
+LogRotateCount = 0
 
 [RegisteredServers]
 # This section contains all registered server entries. The first entry is always the LDS itself.

--- a/linux/platform.c
+++ b/linux/platform.c
@@ -16,6 +16,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 /* system includes */
 #include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
 
 /* local includes */
 #include "../config.h"
@@ -180,4 +182,22 @@ int ualds_platform_mkpath(char *szFilePath)
 
     free(path);
     return ret;
+}
+
+void ualds_getOldLogFilename(const char *szLogFileName, char *szOldFileName, size_t bufSize, int maxRotateCount)
+{
+    time_t rawtime;
+    struct tm * timeinfo;
+    char time_str[80];
+
+    // TODO: 'maxRotateCount' is currently not supported; so always use the date/time filename
+    // get current time in string format
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    strftime(time_str, 80, "%Y-%m-%d_%H-%M-%S", timeinfo);
+
+    strcpy(szOldFileName, szLogFileName);
+    strcat(szOldFileName, "_");
+    strcat(szOldFileName, time_str);
+    strcat(szOldFileName, ".log");
 }

--- a/linux/platform.h
+++ b/linux/platform.h
@@ -69,6 +69,7 @@ int ualds_platform_convertHostnameToIP4(const char* host, char* ip);
 #define ualds_platform_rm rmdir
 #define ualds_platform_mkdir mkdir
 int ualds_platform_mkpath(char *szFilePath);
+void ualds_getOldLogFilename(const char *szLogFileName, char *szOldFileName, size_t bufSize, int maxRotateCount);
 #define ualds_platform_fopen fopen
 #define ualds_platform_fclose fclose
 #define ualds_platform_fread fread

--- a/win32/log.c
+++ b/win32/log.c
@@ -34,6 +34,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 /** internal logger state */
 static int       g_max_size = 100*1024*1024; // 100 MB default value, equivalent in bytes
+static int       g_max_rotate_count = 0; // 0=Do not use log-rotate (use standard logfilenames with date/time); >0 Use the max. number of logfiles
 static int       g_logger_state = 0; /* 0=closed, 1=open */
 static LogTarget g_target = UALDS_LOG_STDERR;
 static LogLevel  g_level = UALDS_LOG_EMERG;
@@ -44,6 +45,7 @@ int ualds_openlog(LogTarget target, LogLevel level)
 {
     int ret = 0;
     char szLogfileSize[10];
+    char szLogRotateCount[10];
     int success;
 
     if (g_logger_state != 0) return 1;
@@ -84,7 +86,27 @@ int ualds_openlog(LogTarget target, LogLevel level)
             ualds_settings_writestring("LogFileSize", szLogfileSize);
             ualds_settings_addemptyline();
         }
-        
+
+        success = ualds_settings_readstring("LogRotateCount", szLogRotateCount, sizeof(szLogRotateCount));
+        if (success == 0)
+        {
+            // convert string to int
+            int tmpLogRotateCount = atoi(szLogRotateCount);
+            if (tmpLogRotateCount > 0)
+            {
+                g_max_rotate_count = min(tmpLogRotateCount, 9999);
+            }
+        }
+        else
+        {
+            // add it to global settings, so that it can be flushed to file, at a later point.
+            ualds_settings_addcomment("#Maximum number of logfiles. This is optional for LogSystem=file. Default is '0' (no restriction in logfiles)");
+            ualds_settings_addemptyline();
+            // write 0 as default value
+            ualds_settings_writestring("LogRotateCount", "0");
+            ualds_settings_addemptyline();
+        }
+
         ualds_settings_endgroup();
 
         g_f = fopen(szLogfile, "a");
@@ -117,9 +139,6 @@ void ualds_log(LogLevel level, const char *format, ...)
     va_list ap;
     long currentPos;
     char szLogfile_backup[PATH_MAX];
-    time_t rawtime;
-    struct tm * timeinfo;
-    char time_str[80];
 
     if (g_logger_state == 0 || level > g_level) return;
 
@@ -153,16 +172,8 @@ void ualds_log(LogLevel level, const char *format, ...)
                 // close log file
                 ualds_closelog();
 
-                strcpy(szLogfile_backup, szLogfile);
-
-                // get current time in string format
-                time(&rawtime);
-                timeinfo = localtime(&rawtime);
-                strftime(time_str, 80, "%Y-%m-%d_%H-%M-%S", timeinfo);
-
-                strcat(szLogfile_backup, "_");
-                strcat(szLogfile_backup, time_str);
-                strcat(szLogfile_backup, ".log");
+                // get old logfile name
+                ualds_getOldLogFilename(szLogfile, szLogfile_backup, sizeof(szLogfile_backup), g_max_rotate_count);
 
                 // rename file
                 MoveFileA(szLogfile, szLogfile_backup);

--- a/win32/platform.h
+++ b/win32/platform.h
@@ -145,6 +145,7 @@ int ualds_platform_rename(const char* from, const char* to);
 int ualds_platform_rm(char *szFilePath);
 int ualds_platform_mkdir(char *szFilePath, int mode);
 int ualds_platform_mkpath(char *szFilePath);
+void ualds_getOldLogFilename(const char *szLogFileName, char *szOldFileName, size_t bufSize, int maxRotateCount);
 UALDS_FILE* ualds_platform_fopen(const char *path, const char *mode);
 int ualds_platform_fclose(UALDS_FILE *fp);
 size_t ualds_platform_fread(void *ptr, size_t size, size_t nmemb, UALDS_FILE *fp);


### PR DESCRIPTION
Currently the logfile is not restricted. This is a Show stopper for production environment if the assume, that machines will run up to 15 or 20 years in the field.
I now added a new log setting 'LogRotateCount' which can be 0 (Default behavior, so no limit) or a number > 0 (max 9999). In that case, the number of logfiles are restricted to the number specified.
If the current logfile gets larger than the specified 'LogFileSize', then the current logfile will be renamed to a new file. If you have specified a rotate Count, the new fill will be of the form "<logfilename>.nnnn.log" where "nnnn" is the number of the rotated logfile. If not all old logfiles are created, the next free number is used. If all old logfiles are present, then the oldest logfile will be deleted and used for the new "old logfile".

The Linux version currently uses the normal date/time logfile schema. The Windows version, will use the old date/time schema if "LogRotateCount=0" and the new schema if the value is > 0.

The following issues should be resolved with this pull request:
- [https://github.com/OPCFoundation/UA-LDS/issues/24](https://github.com/OPCFoundation/UA-LDS/issues/24)
- maybe: [https://github.com/OPCFoundation/UA-LDS/issues/14](https://github.com/OPCFoundation/UA-LDS/issues/14)
