### PR TITLE
Optional: Re-Create self-signed certificate if computer name has changed

### DIFF
--- a/etc/ualds.ini
+++ b/etc/ualds.ini
@@ -66,6 +66,10 @@ MaxAgeRejectedCertificates = 1
 # Enable certificate validation using the given windows certificate store (yes / no)
 Win32StoreCheck = yes
 
+# If this is 'yes' then the certificate will be automatically re-created if the machine name has changed
+# Default behavior is "no"; see also comment in [CertificateInfo]
+ReCreateOwnCertificateOnError = no
+
 [Log]
 # Log System: syslog (system log), file (custom log file)
 LogSystem = file

--- a/ualds.c
+++ b/ualds.c
@@ -573,12 +573,20 @@ static OpcUa_StatusCode ualds_create_selfsigned_certificates(OpcUa_Handle hCerti
         ualds_platform_fwrite(pCert.Data, 1, pCert.Length, f);
         ualds_platform_fclose(f);
     }
+    else
+    {
+        ualds_log(UALDS_LOG_ERR, "ualds_create_selfsigned_certificates: Cloud not create self-signed certificate file. \"%s\"!", g_szCertificateFile);
+    }
 
     f = ualds_platform_fopen(g_szCertificateKeyFile, "wb");
     if (f != NULL)
     {
         ualds_platform_fwrite(prvKey.Key.Data, 1, prvKey.Key.Length, f);
         ualds_platform_fclose(f);
+    }
+    else
+    {
+        ualds_log(UALDS_LOG_ERR, "ualds_create_selfsigned_certificates: Cloud not create self-signed certificate file. \"%s\"!", g_szCertificateKeyFile);
     }
 
 Error:
@@ -646,6 +654,54 @@ static OpcUa_StatusCode ualds_override_validate_certificate(
 }
 #endif /* _WIN32 */
 
+static OpcUa_StatusCode ualds_load_certificate(OpcUa_Handle hCertificateStore)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_load_certificate");
+
+    /* load DER encoded server certificate */
+    uStatus = g_PkiProvider.LoadCertificate(
+        &g_PkiProvider,
+        g_szCertificateFile,
+        hCertificateStore,
+        &g_server_certificate);
+
+    if (OpcUa_IsBad(uStatus))
+    {
+        ualds_log(UALDS_LOG_ERR, "Failed to load server certificate \"%s\"! (0x%08X)", g_szCertificateFile, uStatus);
+        OpcUa_GotoError;
+    }
+
+    /* load DER encoded server certificate private key */
+    uStatus = g_PkiProvider.LoadPrivateKeyFromFile(
+        g_szCertificateKeyFile,
+        OpcUa_Crypto_Encoding_DER,
+        OpcUa_Null,
+        &g_server_key.Key);
+
+    if (OpcUa_IsBad(uStatus))
+    {
+        /* load PEM encoded server certificate private key */
+        uStatus = g_PkiProvider.LoadPrivateKeyFromFile(
+            g_szCertificateKeyFile,
+            OpcUa_Crypto_Encoding_PEM,
+            OpcUa_Null,
+            &g_server_key.Key);
+    }
+
+    if (OpcUa_IsBad(uStatus))
+    {
+        ualds_log(UALDS_LOG_ERR, "Failed to load server private key \"%s\"! (0x%08X)", g_szCertificateKeyFile, uStatus);
+        OpcUa_GotoError;
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+    OpcUa_ByteString_Clear(&g_server_certificate);
+    OpcUa_Key_Clear(&g_server_key);
+OpcUa_FinishErrorHandling;
+}
+
 static OpcUa_StatusCode ualds_security_initialize()
 {
     OpcUa_Handle hCertificateStore = OpcUa_Null;
@@ -659,6 +715,7 @@ static OpcUa_StatusCode ualds_security_initialize()
 OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_security_initialize");
 
     ualds_settings_begingroup("PKI");
+    int reCreateOwnCertificateOnError = 0;
 
     UALDS_SETTINGS_READSTRING(CertificateStorePath);
 
@@ -724,6 +781,14 @@ OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_security_initialize");
         }
     }
 #endif /* _WIN32 */
+    /* Check if we should re-create the own certificate if we found an error */
+    ualds_settings_readstring("ReCreateOwnCertificateOnError", szValue, sizeof(szValue));
+    if (strcmp(szValue, "yes") == 0)
+    {
+        ualds_log(UALDS_LOG_INFO, "ReCreateOwnCertificateOnError is enabled.");
+        reCreateOwnCertificateOnError = 1;
+    }
+
     ualds_settings_endgroup();
 
 #if HAVE_OPENSSL
@@ -750,41 +815,64 @@ OpcUa_InitializeStatus(OpcUa_Module_Server, "ualds_security_initialize");
     {
         ualds_create_selfsigned_certificates(hCertificateStore);
     }
-
-    /* load DER encoded server certificate */
-    uStatus = g_PkiProvider.LoadCertificate(
-        &g_PkiProvider,
-        g_szCertificateFile,
-        hCertificateStore,
-        &g_server_certificate);
-
-    if (OpcUa_IsBad(uStatus))
+    else
     {
-        ualds_log(UALDS_LOG_ERR, "Failed to load server certificate \"%s\"! (0x%08X)", g_szCertificateFile, uStatus);
-        OpcUa_GotoError;
+        if (reCreateOwnCertificateOnError) 
+        {
+            int reCreateCert = 0;
+            /* try to load certificate and check domain name */
+
+            /* loads the server certificate */
+            uStatus = ualds_load_certificate(hCertificateStore);
+            if (OpcUa_IsBad(uStatus))
+            {
+                ualds_log(UALDS_LOG_ERR, "Failed to load server certificate! (0x%08X)", uStatus);
+                reCreateCert = 1;
+            }
+            else
+            {
+                OpcUa_ByteString pSubjectDNS;
+                uStatus = g_PkiProvider.ExtractCertificateData(&g_server_certificate, NULL, NULL, NULL, NULL, &pSubjectDNS, NULL, NULL, NULL);
+                if (OpcUa_IsGood(uStatus))
+                {
+                    if (strcmp(pSubjectDNS.Data, g_szHostname) != 0) 
+                    {
+                        ualds_log(UALDS_LOG_ERR, "Server certificate DNS entry (%s) and current hostname (%s) is NOT the same!", pSubjectDNS.Data, g_szHostname);
+                        reCreateCert = 1;
+                    }
+                }
+                else
+                {
+                    ualds_log(UALDS_LOG_ERR, "Failed to extract server certificate DNS subject! (0x%08X)", uStatus);
+                    reCreateCert = 1;
+                }
+                OpcUa_ByteString_Clear(&pSubjectDNS);
+            }
+
+            if(reCreateCert)
+            {
+                ualds_log(UALDS_LOG_NOTICE, "Re-Creating server certificate!");
+
+                /* clear a previously loaded certificate */
+                OpcUa_ByteString_Clear(&g_server_certificate);
+                OpcUa_Key_Clear(&g_server_key);
+
+                /* create new self-signed certificate  */
+                ualds_create_selfsigned_certificates(hCertificateStore);
+            }
+        }
     }
 
-    /* load DER encoded server certificate private key */
-    uStatus = g_PkiProvider.LoadPrivateKeyFromFile(
-        g_szCertificateKeyFile,
-        OpcUa_Crypto_Encoding_DER,
-        OpcUa_Null,
-        &g_server_key.Key);
-
-    if (OpcUa_IsBad(uStatus))
+    /* check if certificate is already loaded (during the above check) */
+    if (g_server_certificate.Data == OpcUa_Null)
     {
-        /* load PEM encoded server certificate private key */
-        uStatus = g_PkiProvider.LoadPrivateKeyFromFile(
-            g_szCertificateKeyFile,
-            OpcUa_Crypto_Encoding_PEM,
-            OpcUa_Null,
-            &g_server_key.Key);
-    }
-
-    if (OpcUa_IsBad(uStatus))
-    {
-        ualds_log(UALDS_LOG_ERR, "Failed to load server private key \"%s\"! (0x%08X)", g_szCertificateKeyFile, uStatus);
-        OpcUa_GotoError;
+        /* loads the server certificate */
+        uStatus = ualds_load_certificate(hCertificateStore);
+        if (OpcUa_IsBad(uStatus))
+        {
+            ualds_log(UALDS_LOG_ERR, "Failed to load server private key \"%s\"! (0x%08X)", g_szCertificateKeyFile, uStatus);
+            OpcUa_GotoError;
+        }
     }
 
     g_PkiProvider.CloseCertificateStore(&g_PkiProvider, &hCertificateStore);


### PR DESCRIPTION
In some situations the administrator of a machine renames the computer on which the LDS is running. The reason might be: add computer to ActiveDirectory or other IT guidlines.
In this case, the LDS does not work anymore (or better: the clients which connects to the LDS does not accept the server certificate). This now requiries servicing from the manufactor side which is very expensive.
It would be good, if there is an option to re-create the server certificate if the computer name has changed. This is implemented in this pull request. 
The default behavior is still the old (not re-create the certificate), so it must explicit be enabled.

The following is what I have done:
* Reading setting "ReCreateOwnCertificateOnError" from "PKI" section 
* Moved loading of server certificate into function "ualds_load_certificate" 
* Re-Create self-signed certificate if setting is enabled and an error occured during loading or DNS name does not match current hostname (computer name changed) 
* Added logging for failed creation of self-signed certificate files