### PR TITLE
Added config option to never write the configuration file

### DIFF
--- a/etc/ualds.conf
+++ b/etc/ualds.conf
@@ -42,6 +42,9 @@ MessageSecurity = Sign, SignAndEncrypt
 Url = http://opcfoundation.org/UA/SecurityPolicy#Basic256
 MessageSecurity = Sign, SignAndEncrypt
 
+# Defines if this configuration file is never written by the LDS
+#ReadOnlyCfg = 1
+
 [CertificateInfo]
 # Certificate information for creating self-signed certificates on startup
 # This is only used if no certificate exists in the configured path.

--- a/etc/ualds.ini
+++ b/etc/ualds.ini
@@ -31,6 +31,9 @@ Endpoints/size = 1
 Endpoints/0/Url = opc.tcp://[gethostname]:4840
 Endpoints/0/SecurityPolicies = SecurityPolicy_None, SecurityPolicy_Basic128Rsa15, SecurityPolicy_Basic256
 
+# Defines if this configuration file is never written by the LDS
+#ReadOnlyCfg = 1
+
 [SecurityPolicy_None]
 Url = http://opcfoundation.org/UA/SecurityPolicy#None
 MessageSecurity = None

--- a/main.c
+++ b/main.c
@@ -221,6 +221,14 @@ int main(int argc, char* argv[])
     /* initialize logger with correct settings */
     ualds_openlog(logtarget, loglevel);
 
+    /* check if we should never write the configuration file */
+    ualds_settings_begingroup("General");
+    int icfgReadOnly;
+    if (ualds_settings_readint("ReadOnlyCfg", &icfgReadOnly) == 0) {
+        ualds_settings_setReadOnly(icfgReadOnly);
+    }
+    ualds_settings_endgroup();
+
     if (install == 1) {
 #ifdef HAVE_SERVICE_REGISTER
 		/* force an unregister first	*/

--- a/settings.c
+++ b/settings.c
@@ -85,6 +85,7 @@ struct _FileSettings
     int    index;
     int    CurrentGroup;
     int    modified;
+    int    readOnly;  // if this is 1, we never write to the configuration file!
 };
 typedef struct _FileSettings FileSettings;
 
@@ -534,6 +535,9 @@ void UaServer_FSBE_WriteConfigFile_Descriptor(FileSettings *pFS, UALDS_FILE *f)
 static int UaServer_FSBE_WriteConfigFile()
 {
     FileSettings *pFS = &g_settings;
+    if (pFS->readOnly) {
+        return EPERM;
+    }
 
     UALDS_FILE *f_backup = ualds_platform_fopen(pFS->szPathBackup, "w");
     if (f_backup)
@@ -1881,6 +1885,14 @@ int ualds_settings_readstring(const char *szKey, char *szValue, int len)
         szValue[0] = '\0';
     }
 
+    return 0;
+}
+
+/** Sets the read only flag. */
+int ualds_settings_setReadOnly(int readOnly)
+{
+    FileSettings *pFS = &g_settings;
+    pFS->readOnly = readOnly;
     return 0;
 }
 

--- a/settings.h
+++ b/settings.h
@@ -31,6 +31,7 @@ int ualds_settings_close(int flush);
 int ualds_settings_begingroup(const char *szGroup);
 int ualds_settings_endgroup();
 int ualds_settings_readstring(const char *szKey, char *szValue, int len);
+int ualds_settings_setReadOnly(int readOnly);
 #ifdef HAVE_OPCUA_STACK
 int ualds_settings_readuastring(const char *szKey, OpcUa_String *pString);
 #endif /* HAVE_OPCUA_STACK */


### PR DESCRIPTION
The current implementation of the LDS writes the **whole** ualds.ini file during every registration of a OPC UA server. Because this writing is not synchroniesed and the registration for each sever is done via a thread-pool, it happens that the file gets corrupt if several servers register at the same time.
See also: #33 
Also there is no need to write the registered servers in the configuration file. Even there is no need to store this registrations at all. Each server re-register every 30 seconds, so even if the LDS crashes, the servers will almost immediately registered again. So there is no need to store this information.
This pull request adds an optional config setting to disable the writing of the ualds.ini file. In the section [General] you just need to set "ReadOnlyCfg=1". Then the will will never be written and therefor the file can never get corrupt.