### PR TITLE
FindServersOnNetwork: return only records that are greater than the given starting record

### DIFF
--- a/findserversonnetwork.c
+++ b/findserversonnetwork.c
@@ -814,7 +814,7 @@ OpcUa_StatusCode ualds_findserversonnetwork(OpcUa_Endpoint         hEndpoint,
                 if (bIncludeRecord != OpcUa_False)
                 {
                     if (pRequest->StartingRecordId != 0 &&
-                        pResolveContext->record.RecordId < pRequest->StartingRecordId)
+                        pResolveContext->record.RecordId <= pRequest->StartingRecordId)
                     {
                         ualds_log(UALDS_LOG_DEBUG, "ualds_findserversonnetwork: skip record as StartingRecordId is set (%u)", pRequest->StartingRecordId);
                         bIncludeRecord = OpcUa_False;


### PR DESCRIPTION
According to the OPC UA Specification
(https://reference.opcfoundation.org/v104/Core/docs/Part4/5.4.3/) the 
FindServersOnNetwork call shall return "Only records with an identifier 
greater than this number [startingRecordId] will be returned." The current
implementation returns all record that are equal or greater (not smaller).