### PR TITLE
Updated Docker Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN \
         
 EXPOSE 5353
 
-ENTRYPOINT service lds start && bash
+ENTRYPOINT service lds start && tail -f /var/log/opcualds.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM debian:bookworm-slim
 
 ADD / /lds
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 
 ADD / /lds
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ Predefined scripts are available based on CMake.
 
 After a successful build, binary files will be in <build-folder>\bin\[config] and should work as is.
 
+## Running on Linux using Docker
+
+Make sure the avahi-daemon on your host system is either disabled or not installed at all. 
+To remove the avahi-daemon from your host run
+```
+sudo apt purge avahi-daemon
+```
+To only stop and disable the avahi-daemon on your host run
+```
+sudo systemctl stop avahi-daemon
+sudo systemctl disable avahi-daemon
+```
+Finally verify no other service is using the mDNS Port ```5353/udp``` or LDS Port ```4840/tcp``` by running ```sudo netstat -tulnp```.
+To start the LDS you just have to clone the repository and build/execute the image by running ```docker compose up -d```.
+The ```docker-compose.yml``` file defined three dictionary mounts:
+ - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
+ - ```./UALDS/pki```: contains the LDS's public key infrastructure
+ - ```./UALDS/logs```: contains all the containers logs files 
+
 ## Package file structure description
 
 The following tree shows the directory layout of this repo:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Regardless of whether Docker or Docker Compose is chosen the LDS will be using t
  - ```./UALDS/pki```: contains the LDS's public key infrastructure
  - ```./UALDS/logs```: contains all the containers logs files
 
+## Docker Compose
+
+After completing the prerequisites build and execute the image by running ```docker compose up -d```.
+By default the ```docker-compose.yml``` defines the ```network_mode=host``` to ensure your LDS broadcasts the proper hostname via mDNS in your network.
+If you can not use ```network_mode=host``` you can comment it out and uncomment the ports and hostname lines within the ```docker-compose.yml``` file and enter the correct hostname there.
+
 ## Docker
 First build the image using the provided Dockerfile.
 ```
@@ -79,17 +85,6 @@ Running in a separate docker network:
 ```
 docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 --name lds lds:latest 
 ```
-
-## Docker Compose
-
-After completing the prerequisites build and execute the image by running ```docker compose up -d```.
-By default the ```docker-compose.yml``` defines the ```network_mode=host``` to ensure your LDS broadcasts the proper hostname via mDNS in your network.
-If you can not use ```network_mode=host``` you can comment it out and uncomment the ports and hostname part within the compose file and enter the correct hostname there.
-
-The ```docker-compose.yml``` file defines three directory mounts (same as the docker run commands):
- - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
- - ```./UALDS/pki```: contains the LDS's public key infrastructure
- - ```./UALDS/logs```: contains all the containers logs files
 
 ## Package file structure description
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,38 @@ sudo systemctl stop avahi-daemon
 sudo systemctl disable avahi-daemon
 ```
 Finally verify no other service is using the mDNS Port ```5353/udp``` or LDS Port ```4840/tcp``` by running ```sudo netstat -tulnp```.
-To start the LDS you just have to clone the repository and build/execute the image by running ```docker compose up -d```.
-The ```docker-compose.yml``` file defined three dictionary mounts:
+To run the LDS clone the repository and follow the steps described either in [Docker](#docker) or in [Docker Compose](#docker-compose).
+
+## Docker
+First build the image using the provided Dockerfile.
+```
+docker build -t lds .
+```
+
+Running in host mode (shared network interface with host):
+```
+docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -network host lds:latest 
+```
+
+Running in a separate docker network:
+```
+docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 lds:latest 
+```
+The ```docker run``` commands define three directory mounts:
  - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
  - ```./UALDS/pki```: contains the LDS's public key infrastructure
- - ```./UALDS/logs```: contains all the containers logs files 
+ - ```./UALDS/logs```: contains all the containers logs files
+
+## Docker Compose
+
+After completing the prerequisites build and execute the image by running ```docker compose up -d```.
+By default the ```docker-compose.yml``` defines the ```network_mode=host``` to ensure your LDS broadcasts the proper hostname via mDNS in your network.
+If you can not use ```network_mode=host``` you can comment it out and uncomment the ports and hostname part within the compose file and enter the correct hostname there.
+
+The ```docker-compose.yml``` file defines three directory mounts (same as the docker run commands):
+ - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
+ - ```./UALDS/pki```: contains the LDS's public key infrastructure
+ - ```./UALDS/logs```: contains all the containers logs files
 
 ## Package file structure description
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ docker build -t lds .
 
 Running in host mode (shared network interface with host):
 ```
-docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ --network host --name lds lds:latest 
+docker run -d -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ --network host --restart always --name lds lds:latest
 ```
 
 Running in a separate docker network (Replace <hostname> with your actual hostname):
 ```
-docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 --name lds lds:latest 
+docker run -d -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 --restart always --name lds lds:latest
 ```
 
 ## Package file structure description

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ sudo systemctl disable avahi-daemon
 ```
 Finally verify no other service is using the mDNS Port ```5353/udp``` or LDS Port ```4840/tcp``` by running ```sudo netstat -tulnp```.
 To run the LDS clone the repository and follow the steps described either in [Docker](#docker) or in [Docker Compose](#docker-compose).
+Regardless of whether Docker or Docker Compose is chosen the LDS will be using three directory mounts to make its data accessible:
+ - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
+ - ```./UALDS/pki```: contains the LDS's public key infrastructure
+ - ```./UALDS/logs```: contains all the containers logs files
 
 ## Docker
 First build the image using the provided Dockerfile.
@@ -68,17 +72,13 @@ docker build -t lds .
 
 Running in host mode (shared network interface with host):
 ```
-docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -network host lds:latest 
+docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ --network host --name lds lds:latest 
 ```
 
 Running in a separate docker network:
 ```
-docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 lds:latest 
+docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 --name lds lds:latest 
 ```
-The ```docker run``` commands define three directory mounts:
- - ```./UALDS-data/config```: contains the servers config file ```ualds.conf```
- - ```./UALDS/pki```: contains the LDS's public key infrastructure
- - ```./UALDS/logs```: contains all the containers logs files
 
 ## Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Regardless of whether Docker or Docker Compose is chosen the LDS will be using t
  - ```./UALDS/pki```: contains the LDS's public key infrastructure
  - ```./UALDS/logs```: contains all the containers logs files
 
-## Docker Compose
+## Docker Compose (Recommended)
 
 After completing the prerequisites build and execute the image by running ```docker compose up -d```.
 By default the ```docker-compose.yml``` defines the ```network_mode=host``` to ensure your LDS broadcasts the proper hostname via mDNS in your network.
@@ -81,7 +81,7 @@ Running in host mode (shared network interface with host):
 docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ --network host --name lds lds:latest 
 ```
 
-Running in a separate docker network:
+Running in a separate docker network (Replace <hostname> with your actual hostname):
 ```
 docker run -t -v ./UALDS-data/config:/lds/etc -v ./UALDS-data/pki:/opt/opcfoundation/ualds/pki -v ./UALDS-data/logs:/var/log/ -h <hostname> -p 5353:5353/udp -p 4840:4840 --name lds lds:latest 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,18 @@ version: "3.4"
 
 services:
   lds:
-    container_name: lds
     image: lds:latest
     build:
-      context: UA-LDS
       dockerfile: Dockerfile
-    hostname: lds
-    expose:
-      - "5353"
-      - "4840"
-	tty: true
+    #hostname: lds
+    #ports:
+    #  - 5353:5353/udp
+    #  - 4840:4840
+    tty: true
+    volumes:
+      - ./UALDS-data/config:/lds/etc
+      - ./UALDS-data/pki:/opt/opcfoundation/ualds/pki
+      - ./UALDS-data/logs:/var/log/
+    # using network_mode: host to ensure working mDNS Broadcast/Receive
+    # alternatively you can uncomment the port config - make sure to properly set the hostname, so the mDNS Broadcast points to your actual host
+    network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     #ports:
     #  - 5353:5353/udp
     #  - 4840:4840
+    restart: always
     tty: true
     volumes:
       - ./UALDS-data/config:/lds/etc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     #  - 5353:5353/udp
     #  - 4840:4840
     restart: always
-    tty: true
     volumes:
       - ./UALDS-data/config:/lds/etc
       - ./UALDS-data/pki:/opt/opcfoundation/ualds/pki


### PR DESCRIPTION
# Updated Docker Deployment
- Updated Dockerfile to use a currently available image (from: microsoft/dotnet:latest to debian:bookworm-slim)
    - old Dockerfile was not working any more
    - no reasoning behind the old base image (LDS is not a .NET application) 
- Updated docker-compose.yml to use volumes to enable certificate&configuration management
    - Much more convenient to manage certificates and configuration
    - Much easier to backup LDS data
    - (anonymous) container volumes provide no real additional security
- Updated readme.md to contain instructions on how to deploy with docker
    - explaining some common pitfalls (avahi-daemon already running on host, incorrect hostname in docker-compose -> mDNS not working as expected)